### PR TITLE
portability: Avoid void* arithmetics which is a GNU extension

### DIFF
--- a/src/nffs_write.c
+++ b/src/nffs_write.c
@@ -353,7 +353,9 @@ nffs_write_chunk(struct nffs_inode_entry *inode_entry, uint32_t file_offset,
 
         data_offset = cache_block->ncb_file_offset + chunk_off - file_offset;
         rc = nffs_write_over_block(cache_block->ncb_block.nb_hash_entry,
-                                   chunk_off, data + data_offset, chunk_sz);
+                                   chunk_off,
+                                   (const uint8_t *)data + data_offset,
+                                   chunk_sz);
         if (rc != 0) {
             return rc;
         }


### PR DESCRIPTION
Found in context of Zephyr.

Under GNU C, sizeof(void) = 1. This commit simply uses uint8_t.

Pointer arithmetics over void types is:
 * A GNU C extension
 * Not supported by Clang
 * Illegal across all ISO C standards

See also: https://gcc.gnu.org/onlinedocs/gcc/Pointer-Arith.html