### PR TITLE
Move platform #ifdefery to <nffs/os.h>

### DIFF
--- a/include/nffs/config.h
+++ b/include/nffs/config.h
@@ -28,7 +28,7 @@ typedef struct k_mem_slab nffs_os_mempool_t;
 #define NFFS_CONFIG_MAX_AREAS           CONFIG_NFFS_FILESYSTEM_MAX_AREAS
 #define NFFS_CONFIG_MAX_BLOCK_SIZE      CONFIG_NFFS_FILESYSTEM_MAX_BLOCK_SIZE
 
-#else
+#elif MYNEWT
 
 /* Default to Mynewt */
 

--- a/include/nffs/nffs.h
+++ b/include/nffs/nffs.h
@@ -24,11 +24,7 @@
 #include <inttypes.h>
 #include <nffs/config.h>
 #include <nffs/queue.h>
-
-#if __ZEPHYR__
-#include <zephyr/types.h>
-#include <stats.h>
-#endif
+#include <nffs/os.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -213,9 +209,7 @@ struct nffs_block {
 };
 
 struct nffs_file {
-#if !__ZEPHYR__
-    struct fs_ops *fops;
-#endif
+    OS_MULTIFS_CONTAINER;
     struct nffs_inode_entry *nf_inode_entry;
     uint32_t nf_offset;
     uint8_t nf_access_flags;
@@ -283,16 +277,12 @@ struct nffs_cache_inode {
 };
 
 struct nffs_dirent {
-#if !__ZEPHYR__
-    struct fs_ops *fops;
-#endif
+    OS_MULTIFS_CONTAINER;
     struct nffs_inode_entry *nde_inode_entry;
 };
 
 struct nffs_dir {
-#if !__ZEPHYR__
-    struct fs_ops *fops;
-#endif
+    OS_MULTIFS_CONTAINER;
     struct nffs_inode_entry *nd_parent_inode_entry;
     struct nffs_dirent nd_dirent;
 };
@@ -575,7 +565,7 @@ int nffs_write_to_file(struct nffs_file *file, const void *data, int len);
 #define MYNEWT_VAL(val) 0
 #define ASSERT_IF_TEST(cond)
 
-#else
+#elif MYNEWT
 
 /* Default to Mynewt */
 #include "log/log.h"
@@ -583,6 +573,7 @@ int nffs_write_to_file(struct nffs_file *file, const void *data, int len);
 
 #define NFFS_LOG(lvl, ...) \
     LOG_ ## lvl(&nffs_log, LOG_MODULE_NFFS, __VA_ARGS__)
+
 #endif
 
 #ifdef __cplusplus

--- a/include/nffs/os.h
+++ b/include/nffs/os.h
@@ -21,9 +21,29 @@
 #define H_OS_
 
 #include <stdint.h>
-#if __ZEPHYR__
+
+#if MYNEWT
+
+#include "fs/fs.h"
+#include "fs/fs_if.h"
+extern struct fs_ops nffs_ops;
+#define OS_MULTIFS_CONTAINER struct fs_ops *fops
+#define OS_MULTIFS_SETOPS(x) ((x) = &nffs_ops)
+
+#elif __ZEPHYR__
+
 #include <kernel.h>
+#include <zephyr/types.h>
+#include <stats.h>
+#define OS_MULTIFS_CONTAINER
+#define OS_MULTIFS_SETOPS(x)
+
+#else
+
+#error "Unsupported OS"
+
 #endif
+
 #include <nffs/config.h>
 
 #ifdef __cplusplus

--- a/src/nffs_dir.c
+++ b/src/nffs_dir.c
@@ -22,12 +22,6 @@
 #include <nffs/nffs.h>
 #include <nffs/os.h>
 
-#if !__ZEPHYR__
-#include "fs/fs.h"
-#include "fs/fs_if.h"
-struct fs_ops nffs_ops;
-#endif
-
 static struct nffs_dir *
 nffs_dir_alloc(void)
 {
@@ -80,9 +74,7 @@ nffs_dir_open(const char *path, struct nffs_dir **out_dir)
     dir->nd_parent_inode_entry = parent_inode_entry;
     nffs_inode_inc_refcnt(dir->nd_parent_inode_entry);
     memset(&dir->nd_dirent, 0, sizeof dir->nd_dirent);
-#if !__ZEPHYR__
-    dir->fops = &nffs_ops;
-#endif
+    OS_MULTIFS_SETOPS(dir->fops);
 
     *out_dir = dir;
 
@@ -113,9 +105,7 @@ nffs_dir_read(struct nffs_dir *dir, struct nffs_dirent **out_dirent)
     }
 
     nffs_inode_inc_refcnt(child);
-#if !__ZEPHYR__
-    dir->nd_dirent.fops = &nffs_ops;
-#endif
+    OS_MULTIFS_SETOPS(dir->nd_dirent.fops);
     *out_dirent = &dir->nd_dirent;
 
     return 0;

--- a/src/nffs_file.c
+++ b/src/nffs_file.c
@@ -22,12 +22,6 @@
 #include <nffs/nffs.h>
 #include <nffs/os.h>
 
-#if !__ZEPHYR__
-#include "fs/fs.h"
-#include "fs/fs_if.h"
-struct fs_ops nffs_ops;
-#endif
-
 static struct nffs_file *
 nffs_file_alloc(void)
 {
@@ -248,9 +242,7 @@ nffs_file_open(struct nffs_file **out_file, const char *path,
     }
     nffs_inode_inc_refcnt(file->nf_inode_entry);
     file->nf_access_flags = access_flags;
-#if !__ZEPHYR__
-    file->fops = &nffs_ops;
-#endif
+    OS_MULTIFS_SETOPS(file->fops);
 
     *out_file = file;
 

--- a/src/nffs_gc.c
+++ b/src/nffs_gc.c
@@ -19,10 +19,8 @@
 
 #include <assert.h>
 #include <string.h>
-#if __ZEPHYR__
-#include <kernel.h>
-#endif
 #include <nffs/nffs.h>
+#include <nffs/os.h>
 
 /**
  * Keeps track of the number of garbage collections performed.  The exact

--- a/src/nffs_hash.c
+++ b/src/nffs_hash.c
@@ -20,10 +20,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
-#if __ZEPHYR__
-#include <kernel.h>
-#endif
 #include <nffs/nffs.h>
+#include <nffs/os.h>
 
 struct nffs_hash_list *nffs_hash;
 #if !NFFS_CONFIG_USE_HEAP

--- a/src/nffs_misc.c
+++ b/src/nffs_misc.c
@@ -20,9 +20,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#if __ZEPHYR__
-#include <kernel.h>
-#endif
 #include <nffs/nffs.h>
 #include <nffs/os.h>
 


### PR DESCRIPTION
This adds new macros and includes in `<nffs/os.h>`, and updates source files to avoid having to use ifdefery to include features per OS.